### PR TITLE
env-var-unset: cushion the unset command

### DIFF
--- a/build_scripts/build_gcc_9.sh
+++ b/build_scripts/build_gcc_9.sh
@@ -34,6 +34,9 @@ install_dir=${HOME}/opt/gcc-${gcc_version}
 build_dir=/var/tmp/$(whoami)/gcc-${gcc_version}_build
 source_dir=/var/tmp/$(whoami)/gcc-${gcc_version}_source
 tarfile_dir=/var/tmp/$(whoami)/gcc-${gcc_version}_tarballs
+rm -rf ${build_dir}
+rm -rf ${source_dir}
+rm -rf ${tarfile_dir}
 
 # String which gets embedded into gcc version info, can be accessed at
 # runtime. Use to indicate who/what/when has built this compiler.
@@ -224,9 +227,13 @@ __banner Cleaning environment
 U=$USER
 H=$HOME
 
+RGX_ENV_VAR='^[0-9A-Za-z_].*'
+
 for i in $(env | awk -F"=" '{print $1}') ;
 do
-    unset $i || true   # ignore unset fails
+if [[ $i =~ ${rgx_env_var} ]]; then
+	unset $i || true   # ignore unset fails
+fi
 done
 
 # restore


### PR DESCRIPTION
Currently, if an ENV-variable contains a leading
":", the unset fails with "Incorrect environment
variable name". We check whether an env-var conforms
to a regex. Also, we remove the directories used
in the build, in order to be able to re-launch
the script in case of failures (e.g., one forgot
to launch it in a screen session of the remote)

Signed-off-by: sk <60398690+serkazi@users.noreply.github.com>